### PR TITLE
Add nuspec file

### DIFF
--- a/nuspec/nuget/Cake.Svn.nuspec
+++ b/nuspec/nuget/Cake.Svn.nuspec
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <metadata xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <id>Cake.Svn</id>
+    <title>Cake.Svn</title>
+    <version>0.0.0</version>
+    <authors>Martin Björkström, Pascal Berger and contributors</authors>
+    <owners>cake-contrib, mholo65, pascalberger</owners>
+    <summary>Addin that extends the Cake build automation system with Subversion features using SharpSvn.</summary>
+    <description>
+Addin that extends the Cake build automation system with Subversion features using SharpSvn.
+    </description>
+    <licenseUrl>https://github.com/cake-contrib/Cake.Svn/blob/develop/LICENSE</licenseUrl>
+    <projectUrl>http://cake-contrib.github.io/Cake.Svn/</projectUrl>
+    <iconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <copyright>Copyright © 2017 Cake.Svn contributors</copyright>
+    <tags>Cake Script Subversion</tags>
+    <releaseNotes>https://github.com/cake-contrib/Cake.Svn/releases/tag/0.1.0</releaseNotes>
+  </metadata>
+  <files>
+    <file src="Cake.Svn.dll" target="lib\net46" />
+    <file src="Cake.Svn.pdb" target="lib\net46" />
+    <file src="Cake.Svn.xml" target="lib\net46" />
+    <file src="SharpSvn.dll" target="lib\net46" />
+  </files>
+</package>

--- a/src/Cake.Svn.sln
+++ b/src/Cake.Svn.sln
@@ -1,11 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Svn", "Cake.Svn\Cake.Svn.csproj", "{AD32E5A7-C7D1-47BE-92A6-36368EE78953}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Svn.Tests", "Cake.Svn.Tests\Cake.Svn.Tests.csproj", "{8F154251-B8D3-4E42-A977-E145A27F9B34}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{7287F939-CC23-4210-817F-CB33257E67F2}"
+	ProjectSection(SolutionItems) = preProject
+		..\setup.cake = ..\setup.cake
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuspec", "nuspec", "{663B9533-C227-4980-A500-B570F3A545CF}"
+	ProjectSection(SolutionItems) = preProject
+		..\nuspec\nuget\Cake.Svn.nuspec = ..\nuspec\nuget\Cake.Svn.nuspec
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -24,5 +34,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{663B9533-C227-4980-A500-B570F3A545CF} = {7287F939-CC23-4210-817F-CB33257E67F2}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add nuspec file for having the NuGet package being created. 

SharpSvn assemblies are currently shipped as part of the NuGet package and not embedded with Cake.Svn which can lead to potential versioning conflicts with other addins. I created #18 for this.