### PR TITLE
(GH-2) Add svn status command

### DIFF
--- a/src/Cake.Svn.Tests/Cake.Svn.Tests.csproj
+++ b/src/Cake.Svn.Tests/Cake.Svn.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Fixtures\Add\SvnAdderFixture.cs" />
     <Compile Include="Fixtures\Export\SvnExporterFixture.cs" />
     <Compile Include="Fixtures\Info\SvnInfoFixture.cs" />
+    <Compile Include="Fixtures\Status\SvnStatusFixture.cs" />
     <Compile Include="Fixtures\Update\SvnUpdaterFixture.cs" />
     <Compile Include="Fixtures\Vacuum\SvnVacuumFixture.cs" />
     <Compile Include="Internal\Extensions\CheckArgumentExtensionsTests.cs" />
@@ -81,6 +82,8 @@
     <Compile Include="Fixtures\Checkout\SvnCheckouterFixture.cs" />
     <Compile Include="Unit\Checkout\SvnCheckouterTests.cs" />
     <Compile Include="Unit\Checkout\SvnCheckoutSettingsTests.cs" />
+    <Compile Include="Unit\Status\SvnStatusSettingsTests.cs" />
+    <Compile Include="Unit\Status\SvnStatusTests.cs" />
     <Compile Include="Unit\Update\SvnUpdaterTests.cs" />
     <Compile Include="Unit\Update\SvnUpdateSettingsTests.cs" />
     <Compile Include="Unit\Vacuum\SvnVacuumSettingsTests.cs" />

--- a/src/Cake.Svn.Tests/Fixtures/Status/SvnStatusFixture.cs
+++ b/src/Cake.Svn.Tests/Fixtures/Status/SvnStatusFixture.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Svn.Status;
+using NSubstitute;
+
+namespace Cake.Svn.Tests.Fixtures.Status
+{
+    internal sealed class SvnStatusFixture
+    {
+        internal ICakeEnvironment Environment { get; set; }
+        internal ISvnClient SvnClient { get; set; }
+        internal SvnStatusSettings Settings { get; set; }
+        internal DirectoryPath DirectoryPath { get; set; }
+        internal FilePath FilePath { get; set; }
+        internal Func<ISvnClient> GetSvnClient;
+
+        internal SvnStatusFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            SvnClient = Substitute.For<ISvnClient>();
+            Settings = new SvnStatusSettings();
+            DirectoryPath = new DirectoryPath(@"C:\test\");
+            FilePath = new FilePath(@"C:\test\test.cs");
+            GetSvnClient = () => SvnClient;
+        }
+
+        internal SvnStatusTool CreateStatus()
+        {
+            return new SvnStatusTool(Environment, GetSvnClient);
+        }
+
+        internal IEnumerable<SvnStatusResult> Status()
+        {
+            var svnStatus = CreateStatus();
+            var list = new List<SvnStatusResult>();
+            list.AddRange(svnStatus.Status(DirectoryPath, Settings));
+            list.AddRange(svnStatus.Status(FilePath, Settings));
+
+            return list;
+        }
+    }
+}

--- a/src/Cake.Svn.Tests/Unit/Status/SvnStatusSettingsTests.cs
+++ b/src/Cake.Svn.Tests/Unit/Status/SvnStatusSettingsTests.cs
@@ -1,0 +1,122 @@
+﻿using Cake.Svn.Status;
+using Xunit;
+
+namespace Cake.Svn.Tests.Unit.Status
+{
+
+    public class SvnStatusSettingsTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Set_Infinity_Depth_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.Equal(SvnDepth.Infinity, settings.Depth);
+            }
+
+            [Fact]
+            public void Should_IgnoreExternals_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.True(settings.IgnoreExternals);
+            }
+
+            [Fact]
+            public void Should_Not_IgnoreWorkingCopyStatus_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.IgnoreWorkingCopyStatus);
+            }
+
+            [Fact]
+            public void Should_Not_KeepDepth_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.KeepDepth);
+            }
+
+            [Fact]
+            public void Should_Not_RetrieveAllEntries_ByDefault()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.RetrieveAllEntries);
+            }
+
+            [Fact]
+            public void Should_Not_RetrieveIgnoredEntries_ByDefault()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.RetrieveIgnoredEntries);
+            }
+
+            [Fact]
+            public void Should_Not_RetrieveRemoteStatus_ByDefault()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.RetrieveRemoteStatus);
+            }
+
+            [Fact]
+            public void Should_Set_Revision_To_Null_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.Null(settings.Revision);
+            }
+
+            [Fact]
+            public void Should_Set_ThrowOnCancel_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.True(settings.ThrowOnCancel);
+            }
+
+            [Fact]
+            public void Should_Set_ThrowOnError_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.True(settings.ThrowOnError);
+            }
+
+            [Fact]
+            public void Should_Set_ThrowOnWarning_By_Default()
+            {
+                // Given, When
+                var settings = new SvnStatusSettings();
+
+                // Then
+                Assert.False(settings.ThrowOnWarning);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn.Tests/Unit/Status/SvnStatusTests.cs
+++ b/src/Cake.Svn.Tests/Unit/Status/SvnStatusTests.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using Cake.Svn.Status;
+using Cake.Svn.Tests.Fixtures.Status;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Svn.Tests.Unit.Status
+{
+    public sealed class SvnStatusTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_NotThrow_If_Parameters_AreSet()
+            {
+                // Given
+                var fixture = new SvnStatusFixture();
+
+                // When
+                fixture.CreateStatus();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    Environment = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("environment", () => fixture.CreateStatus());
+            }
+
+            [Fact]
+            public void Should_Throw_If_GetSvnClient_Is_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    GetSvnClient = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("clientFactoryMethod", () => fixture.CreateStatus());
+            }
+        }
+
+        public sealed class TheStatusMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Is_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    Settings = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("settings", () => fixture.Status());
+            }
+
+            [Fact]
+            public void Should_Throw_If_DirectoryPath_Is_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    DirectoryPath = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("directoryPath", () => fixture.Status());
+            }
+
+            [Fact]
+            public void Should_Throw_If_FilePath_Is_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    FilePath = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("filePath", () => fixture.Status());
+            }
+
+            [Fact]
+            public void Should_Not_Force_Credentials_If_Null()
+            {
+                // Given
+                var fixture = new SvnStatusFixture
+                {
+                    Settings = new SvnStatusSettings
+                    {
+                        Credentials = null
+                    }
+                };
+
+                // When
+                fixture.Status();
+
+                // Then
+                fixture.SvnClient.DidNotReceive().ForceCredentials(Arg.Any<SvnCredentials>());
+            }
+
+            [Fact]
+            public void Should_Force_Credentials_If_Not_Null()
+            {
+                // Given
+                SvnCredentials credentials = new SvnCredentials
+                {
+                    Username = "username",
+                    Password = "p@ssw0rd"
+                };
+
+                var fixture = new SvnStatusFixture
+                {
+                    Settings = new SvnStatusSettings
+                    {
+                        Credentials = credentials
+                    }
+                };
+
+                // When
+                fixture.Status();
+
+                // Then
+                fixture.SvnClient.Received(2).ForceCredentials(credentials);
+            }
+
+            [Fact]
+            public void Should_Proxy_Call_To_CreateStatus_OnSvnClient()
+            {
+                // Given
+                var fixture = new SvnStatusFixture();
+
+                // When
+                fixture.Status();
+
+                // Then
+                fixture.SvnClient.Received(1).Status(fixture.DirectoryPath.ToString(), fixture.Settings);
+                fixture.SvnClient.Received(1).Status(fixture.FilePath.ToString(), fixture.Settings);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn/Cake.Svn.csproj
+++ b/src/Cake.Svn/Cake.Svn.csproj
@@ -72,12 +72,17 @@
     <Compile Include="Internal\Extensions\SvnDepthExtensions.cs" />
     <Compile Include="Internal\Extensions\SvnLineStyleExtensions.cs" />
     <Compile Include="Internal\Extensions\SvnNodeKindExtensions.cs" />
+    <Compile Include="Internal\Extensions\SvnStatusExtensions.cs" />
     <Compile Include="ISvnClient.cs" />
     <Compile Include="Internal\SharpSvnClient.cs" />
     <Compile Include="Export\SvnExporter.cs" />
     <Compile Include="Export\SvnExportResult.cs" />
     <Compile Include="Export\SvnExportSettings.cs" />
     <Compile Include="Export\SvnExportSettingsExtensions.cs" />
+    <Compile Include="Status\SvnStatusTool.cs" />
+    <Compile Include="Status\SvnStatusResult.cs" />
+    <Compile Include="Status\SvnStatusSettings.cs" />
+    <Compile Include="Status\SvnStatusSettingsExtensions.cs" />
     <Compile Include="SvnAliases.Add.cs" />
     <Compile Include="SvnAliases.CleanUp.cs" />
     <Compile Include="SvnAliases.cs" />
@@ -93,6 +98,7 @@
     <Compile Include="SvnLineStyle.cs" />
     <Compile Include="SvnRemoteSettings.cs" />
     <Compile Include="SvnSettings.cs" />
+    <Compile Include="SvnStatus.cs" />
     <Compile Include="SvnTool.cs" />
     <Compile Include="Checkout\SvnCheckouter.cs" />
     <Compile Include="Checkout\SvnCheckoutSettings.cs" />
@@ -106,9 +112,8 @@
     <Compile Include="Vacuum\SvnVacuum.cs" />
     <Compile Include="Vacuum\SvnVacuumSettings.cs" />
     <Compile Include="Vacuum\SvnVacuumSettingsExtensions.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="SvnAliases.Export.cs" />
+    <Compile Include="SvnAliases.Status.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Core">

--- a/src/Cake.Svn/ISvnClient.cs
+++ b/src/Cake.Svn/ISvnClient.cs
@@ -6,6 +6,7 @@ using Cake.Svn.CleanUp;
 using Cake.Svn.Delete;
 using Cake.Svn.Export;
 using Cake.Svn.Info;
+using Cake.Svn.Status;
 using Cake.Svn.Update;
 using Cake.Svn.Vacuum;
 
@@ -102,5 +103,13 @@ namespace Cake.Svn
         /// <param name="settings">Settings to use.</param>
         /// <returns><c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.</returns>
         bool Vacuum(string directoryPath, SvnVacuumSettings settings);
+
+        /// <summary>
+        /// Gets the status of working copy files and directories.
+        /// </summary>
+        /// <param name="fileOrDirectoryPath">The path to the local file or directory.</param>
+        /// <param name="settings">Settings to use.</param>
+        /// <returns>Result of the status operation.</returns>
+        IEnumerable<SvnStatusResult> Status(string fileOrDirectoryPath, SvnStatusSettings settings);
     }
 }

--- a/src/Cake.Svn/Internal/Extensions/SvnStatusExtensions.cs
+++ b/src/Cake.Svn/Internal/Extensions/SvnStatusExtensions.cs
@@ -1,0 +1,42 @@
+﻿namespace Cake.Svn.Internal.Extensions
+{
+    internal static class SvnStatusExtensions
+    {
+        internal static SvnStatus ToSvnStatus(this SharpSvn.SvnStatus svnStatus)
+        {
+            switch (svnStatus)
+            {
+                case SharpSvn.SvnStatus.None:
+                    return SvnStatus.None;
+                case SharpSvn.SvnStatus.NotVersioned:
+                    return SvnStatus.NotVersioned;
+                case SharpSvn.SvnStatus.Normal:
+                    return SvnStatus.Normal;
+                case SharpSvn.SvnStatus.Added:
+                    return SvnStatus.Added;
+                case SharpSvn.SvnStatus.Missing:
+                    return SvnStatus.Missing;
+                case SharpSvn.SvnStatus.Deleted:
+                    return SvnStatus.Deleted;
+                case SharpSvn.SvnStatus.Replaced:
+                    return SvnStatus.Replaced;
+                case SharpSvn.SvnStatus.Modified:
+                    return SvnStatus.Modified;
+                case SharpSvn.SvnStatus.Merged:
+                    return SvnStatus.Merged;
+                case SharpSvn.SvnStatus.Conflicted:
+                    return SvnStatus.Conflicted;
+                case SharpSvn.SvnStatus.Ignored:
+                    return SvnStatus.Ignored;
+                case SharpSvn.SvnStatus.Obstructed:
+                    return SvnStatus.Obstructed;
+                case SharpSvn.SvnStatus.External:
+                    return SvnStatus.External;
+                case SharpSvn.SvnStatus.Incomplete:
+                    return SvnStatus.Incomplete;
+                default:
+                    return SvnStatus.Zero;
+            }
+        }
+    }
+}

--- a/src/Cake.Svn/Internal/SharpSvnClient.cs
+++ b/src/Cake.Svn/Internal/SharpSvnClient.cs
@@ -9,6 +9,7 @@ using Cake.Svn.Delete;
 using Cake.Svn.Export;
 using Cake.Svn.Info;
 using Cake.Svn.Internal.Extensions;
+using Cake.Svn.Status;
 using Cake.Svn.Update;
 using Cake.Svn.Vacuum;
 using SharpSvn;
@@ -153,6 +154,33 @@ namespace Cake.Svn.Internal
         public bool Vacuum(string directoryPath, SvnVacuumSettings settings)
         {
             return Vacuum(directoryPath, settings.ToSvnVacuumArgs());
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<SvnStatusResult> Status(string fileOrDirectoryPath, SvnStatusSettings settings)
+        {
+            var statusResults = new List<SvnStatusEventArgs>();
+
+            Status(
+                fileOrDirectoryPath,
+                settings.ToSvnStatusArgs(),
+                statusHandler: (s, e) =>
+                {
+                    statusResults.Add(e);
+                });
+
+            return
+                (from eventArg in statusResults
+                 select new SvnStatusResult(
+                     eventArg.RepositoryId,
+                     eventArg.RepositoryRoot,
+                     eventArg.LastChangeAuthor,
+                     eventArg.Revision,
+                     eventArg.LastChangeRevision,
+                     eventArg.Uri,
+                     eventArg.Path,
+                     eventArg.FullPath,
+                     eventArg.LocalNodeStatus.ToSvnStatus())).ToList();
         }
     }
 }

--- a/src/Cake.Svn/Status/SvnStatusResult.cs
+++ b/src/Cake.Svn/Status/SvnStatusResult.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using Cake.Svn.Internal.Extensions;
 
-namespace Cake.Svn.Info
+namespace Cake.Svn.Status
 {
     /// <summary>
-    /// Result for <see cref="SvnInfo"/>.
+    /// Result for <see cref="SvnStatusTool"/>.
     /// </summary>
-    public sealed class SvnInfoResult
+    public sealed class SvnStatusResult
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SvnInfoResult"/> class.
+        /// Initializes a new instance of the <see cref="SvnStatusResult"/> class.
         /// </summary>
         /// <param name="repositoryId">The UUID of the Subversion repository.</param>
         /// <param name="repositoryRoot">The repository root Uri.</param>
@@ -17,11 +17,11 @@ namespace Cake.Svn.Info
         /// <param name="revision">The revision of the node.</param>
         /// <param name="lastChangedRevision">The last changed revision of the node.</param>
         /// <param name="uri">The full Uri of the node.</param>
-        /// <param name="path">The path of the file. The local path if requisting working version, 
+        /// <param name="path">The path of the file. The local path if requisting working version,
         /// otherwise the name of the file at the specified version.</param>
         /// <param name="fullPath">The path in a normalized format.</param>
-        /// <param name="nodeKind">The kind of the Subversion node.</param>
-        public SvnInfoResult(
+        /// <param name="svnStatus">The status of the Subversion node.</param>
+        public SvnStatusResult(
             Guid repositoryId,
             Uri repositoryRoot,
             string lastChangedAuthor,
@@ -30,7 +30,7 @@ namespace Cake.Svn.Info
             Uri uri,
             string path,
             string fullPath,
-            SvnKind nodeKind)
+            SvnStatus svnStatus)
         {
 #pragma warning disable SA1123 // Do not place regions within elements
             #region DupFinder Exclusion
@@ -48,13 +48,13 @@ namespace Cake.Svn.Info
             Uri = uri;
             Path = path;
             FullPath = fullPath;
-            NodeKind = nodeKind;
+            SvnStatus = svnStatus;
 
             #endregion
         }
 
         /// <summary>
-        /// Gets the UUID of the repository (if available). Otherwise Guid.Empty.
+        /// Gets the UUID of the repository (if available). Otherwise <see cref="Guid.Empty"/>.
         /// </summary>
         public Guid RepositoryId { get; }
 
@@ -91,12 +91,12 @@ namespace Cake.Svn.Info
 
         /// <summary>
         /// Gets the path in normalized format.
-        /// </summary> 
+        /// </summary>
         public string FullPath { get; }
 
         /// <summary>
-        /// Gets the kind of the subversion node.
+        /// Gets the status of the subversion node.
         /// </summary>
-        public SvnKind NodeKind { get; }
+        public SvnStatus SvnStatus { get; }
     }
 }

--- a/src/Cake.Svn/Status/SvnStatusSettings.cs
+++ b/src/Cake.Svn/Status/SvnStatusSettings.cs
@@ -1,0 +1,58 @@
+﻿namespace Cake.Svn.Status
+{
+    /// <summary>
+    /// Settings for <see cref="SvnStatusTool"/>
+    /// </summary>
+    public sealed class SvnStatusSettings : SvnRemoteSettings
+    {
+        /// <summary>
+        /// Gets or sets the value of the revision on which Subversion should operate.
+        /// Use <c>null</c> for the default revision, <c>-1</c> for the head revision and numbers
+        /// bigger than -1 for a certain revision.
+        /// </summary>
+        public long? Revision { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tree depth to which Subversion should limit the scope.
+        /// </summary>
+        public SvnDepth Depth { get; set; } = SvnDepth.Infinity;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether externals should be ignored.
+        /// </summary>
+        public bool IgnoreExternals { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether working copy status should be ignored.
+        /// </summary>
+        public bool IgnoreWorkingCopyStatus { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether in addition to updating paths also the sticky ambient 
+        /// depth value must be set to depth.
+        /// </summary>
+
+        /// <summary>
+        /// Gets or sets a value indicating whether excluded nodes should be shown as additions
+        /// if also <see cref="RetrieveRemoteStatus"/> is set to <c>true</c>.
+        /// This behavior is the same as an update with <see cref="Cake.Svn.Update.SvnUpdateSettings.KeepDepth"/>.
+        /// </summary>
+        public bool KeepDepth { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all status properties should be retrieved.
+        /// </summary>
+        public bool RetrieveAllEntries { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether ignored files should be retrieved.
+        /// </summary>
+        public bool RetrieveIgnoredEntries { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the repository should be contacted
+        /// to retrieve out of date information
+        /// </summary>
+        public bool RetrieveRemoteStatus { get; set; }
+    }
+}

--- a/src/Cake.Svn/Status/SvnStatusSettingsExtensions.cs
+++ b/src/Cake.Svn/Status/SvnStatusSettingsExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Cake.Svn.Internal.Extensions;
+using SharpSvn;
+
+namespace Cake.Svn.Status
+{
+    internal static class SvnStatusSettingsExtensions
+    {
+        internal static SvnStatusArgs ToSvnStatusArgs(this SvnStatusSettings settings)
+        {
+            settings.NotNull(nameof(settings));
+
+            return (new SvnStatusArgs
+            {
+                Depth = settings.Depth.ToSharpSvn(),
+                Revision = !settings.Revision.HasValue ? new SvnRevision() :
+                    (settings.Revision < 0 ? SvnRevision.Head : new SvnRevision(settings.Revision.Value)),
+                IgnoreExternals = settings.IgnoreExternals,
+                IgnoreWorkingCopyStatus = settings.IgnoreWorkingCopyStatus,
+                KeepDepth = settings.KeepDepth,
+                RetrieveAllEntries = settings.RetrieveAllEntries,
+                RetrieveIgnoredEntries = settings.RetrieveIgnoredEntries,
+                RetrieveRemoteStatus = settings.RetrieveRemoteStatus
+            }).SetBaseSettings(settings);
+        }
+    }
+}

--- a/src/Cake.Svn/Status/SvnStatusTool.cs
+++ b/src/Cake.Svn/Status/SvnStatusTool.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Svn.Internal.Extensions;
+
+namespace Cake.Svn.Status
+{
+    /// <summary>
+    /// Class for getting file and directory status for Subversion directory trees.
+    /// </summary>
+    public sealed class SvnStatusTool : SvnTool<SvnStatusSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SvnStatusTool"/> class.
+        /// </summary>
+        /// <param name="environment">The Cake environment.</param>
+        /// <param name="clientFactoryMethod">Method to use to initialize a Subversion client.</param>
+        public SvnStatusTool(ICakeEnvironment environment, Func<ISvnClient> clientFactoryMethod)
+            : base(clientFactoryMethod)
+        {
+            environment.NotNull(nameof(environment));
+            clientFactoryMethod.NotNull(nameof(clientFactoryMethod));
+
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Gets Subversion status about the directory at <paramref name="directoryPath"/>.
+        /// </summary>
+        /// <param name="directoryPath">The directory.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The Subversion status.</returns>
+        public IEnumerable<SvnStatusResult> Status(DirectoryPath directoryPath, SvnStatusSettings settings)
+        {
+            settings.NotNull(nameof(settings));
+            directoryPath.NotNull(nameof(directoryPath));
+
+            return Status(directoryPath.MakeAbsolute(_environment).ToString(), settings);
+        }
+
+        /// <summary>
+        /// Gets Subversion status about the file at <paramref name="filePath"/>.
+        /// </summary>
+        /// <param name="filePath">The file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The Subversion status.</returns>
+        public IEnumerable<SvnStatusResult> Status(FilePath filePath, SvnStatusSettings settings)
+        {
+            settings.NotNull(nameof(settings));
+            filePath.NotNull(nameof(filePath));
+
+            return Status(filePath.MakeAbsolute(_environment).ToString(), settings);
+        }
+
+        /// <summary>
+        /// Gets Subversion status about the file or directory at <paramref name="fileOrDirectoryPath"/>.
+        /// </summary>
+        /// <param name="fileOrDirectoryPath">The file or directory path.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The Subversion status.</returns>
+        private IEnumerable<SvnStatusResult> Status(string fileOrDirectoryPath, SvnStatusSettings settings)
+        {
+            settings.NotNull(nameof(settings));
+            fileOrDirectoryPath.NotNullOrWhiteSpace(nameof(fileOrDirectoryPath));
+
+            using (var client = GetClient())
+            {
+                client.TrustServerCertificate = settings.Insecure;
+                if (settings.Credentials != null)
+                {
+                    client.ForceCredentials(settings.Credentials);
+                }
+
+                return client.Status(fileOrDirectoryPath, settings);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn/SvnAliases.Status.cs
+++ b/src/Cake.Svn/SvnAliases.Status.cs
@@ -1,0 +1,156 @@
+﻿using System.Collections.Generic;
+using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Svn.Status;
+
+namespace Cake.Svn
+{
+    public partial class SvnAliases
+    {
+        /// <summary>
+        /// Gets Subversion status about the directory at <paramref name="directoryPath"/>.
+        /// The result list contains recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// the overload <see cref="SvnStatusDirectory(ICakeContext, DirectoryPath, SvnStatusSettings)"/>
+        /// can be used with chaning the settings parameter.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="directoryPath">The directory.</param>
+        /// <returns>
+        /// A result list containing recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// the overload <see cref="SvnStatusDirectory(ICakeContext, DirectoryPath, SvnStatusSettings)"/>
+        /// can be used with changing the settings parameter.
+        /// </returns>
+        /// <example>
+        /// <para>
+        /// Gets Subversion status about the directory at <paramref name="directoryPath"/>.
+        /// The result list contains recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// the overload <see cref="SvnStatusDirectory(ICakeContext, DirectoryPath, SvnStatusSettings)"/>
+        /// can be used with changing the settings parameter.
+        /// </para>
+        /// <code>
+        /// <![CDATA[
+        ///     var localDirectoryStatus = SvnStatusDirectory(@"C:\project\src\");
+        ///
+        ///     foreach(var svnStatusResult in localDirectoryStatus)
+        ///     {
+        ///         Verbose("Path: {0}", svnStatusResult.Path);
+        ///     }
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Status")]
+        [CakeNamespaceImport("Cake.Svn.Status")]
+        public static IEnumerable<SvnStatusResult> SvnStatusDirectory(this ICakeContext context, DirectoryPath directoryPath)
+        {
+            return SvnStatusDirectory(context, directoryPath, null);
+        }
+
+        /// <summary>
+        /// Gets Subversion status about the directory at <paramref name="directoryPath"/> with specific settings.
+        /// The result list contains recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// change the <see cref="SvnDepth"/> on <paramref name="settings"/>.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="directoryPath">The directory.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>A result list containing recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// change the <see cref="SvnDepth"/> on <paramref name="settings"/></returns>
+        /// <example>
+        /// <para>
+        /// Gets Subversion status about the directory at <paramref name="directoryPath"/> with specific settings.
+        /// The result list contains recursive status about the <paramref name="directoryPath"/>
+        /// (<see cref="SvnDepth.Infinity"/>). To get status with another <see cref="SvnDepth"/>
+        /// change the <see cref="SvnDepth"/> on <paramref name="settings"/>.
+        /// </para>
+        /// <code>
+        /// <![CDATA[
+        ///     var svnStatusSettings = new SvnStatusSettings
+        ///     {
+        ///         Depth = SvnDepth.Unknown;
+        ///     };
+        ///
+        ///     var localDirectoryStatus = SvnStatusDirectory(@"C:\project\src\", svnStatusSettings);
+        ///
+        ///     foreach(var svnStatusResult in localDirectoryStatus)
+        ///     {
+        ///         Verbose("Path: {0}", svnStatusResult.Path);
+        ///     }
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Status")]
+        [CakeNamespaceImport("Cake.Svn.Status")]
+        public static IEnumerable<SvnStatusResult> SvnStatusDirectory(this ICakeContext context, DirectoryPath directoryPath, SvnStatusSettings settings)
+        {
+            var commands = new SvnStatusTool(context.Environment, SvnClientFactoryMethod);
+
+            return commands.Status(directoryPath, settings ?? new SvnStatusSettings());
+        }
+
+        /// <summary>
+        /// Gets Subversion status about the file at <paramref name="filePath"/>.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="filePath">The file.</param>
+        /// <returns>The Subversion status.</returns>
+        /// <example>
+        /// <para>Gets Subversion status about the file at <paramref name="filePath"/>.</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var localFileStatus = SvnFileStatus(@"C:\project\src\file.cs");
+        ///
+        ///     Verbose("Path: {0}", localFileStatus.Path);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Status")]
+        [CakeNamespaceImport("Cake.Svn.Status")]
+        public static IEnumerable<SvnStatusResult> SvnStatusFile(this ICakeContext context, FilePath filePath)
+        {
+            return SvnStatusFile(context, filePath, null);
+        }
+
+        /// <summary>
+        /// Gets Subversion status about file at <paramref name="filePath"/> with specific settings.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="filePath">The file.</param>
+        /// <param name="settings">The settings.</param>
+        /// <returns>The Subversion status. If no status about the file is available on Subversion
+        /// <c>null</c> will be returned. For this <see cref="SvnSettings.ThrowOnError"/> has to be set to <c>false</c>.
+        /// </returns>
+        /// <example>
+        /// <para>Gets Subversion status about file at <paramref name="filePath"/> with specific settings.</para>
+        /// <code>
+        /// <![CDATA[
+        ///     var svnStatusSettings = new SvnStatusSettings
+        ///     {
+        ///         Depth = SvnDepth.Unknown;
+        ///     };
+        ///
+        ///     var localFileStatus = SvnFileStatus(@"C:\project\src\", svnStatusSettings);
+        ///
+        ///     Verbose("Path: {0}", localFileStatus.Path);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Status")]
+        [CakeNamespaceImport("Cake.Svn.Status")]
+        public static IEnumerable<SvnStatusResult> SvnStatusFile(this ICakeContext context, FilePath filePath, SvnStatusSettings settings)
+        {
+            var commands = new SvnStatusTool(context.Environment, SvnClientFactoryMethod);
+
+            return commands.Status(filePath, settings ?? new SvnStatusSettings());
+        }
+    }
+}

--- a/src/Cake.Svn/SvnStatus.cs
+++ b/src/Cake.Svn/SvnStatus.cs
@@ -1,0 +1,69 @@
+﻿namespace Cake.Svn
+{
+    /// <summary>
+    /// Status of Subversion files.
+    /// </summary>
+    public enum SvnStatus
+    {
+        /// <summary>
+        /// Zero value. Never used by Subversion
+        /// </summary>
+        Zero = 0,
+        /// <summary>
+        /// does not exist
+        /// </summary>
+        None = 1,
+        /// <summary>
+        /// is not a versioned thing in this wc
+        /// </summary>
+        NotVersioned = 2,
+        /// <summary>
+        /// exists, but uninteresting
+        /// </summary>
+        Normal = 3,
+        /// <summary>
+        /// is scheduled for addition
+        /// </summary>
+        Added = 4,
+        /// <summary>
+        /// under v.c., but is missing
+        /// </summary>
+        Missing = 5,
+        /// <summary>
+        /// scheduled for deletion
+        /// </summary>
+        Deleted = 6,
+        /// <summary>
+        /// was deleted and then re-added
+        /// </summary>
+        Replaced = 7,
+        /// <summary>
+        /// text or props have been modified
+        /// </summary>
+        Modified = 8,
+        /// <summary>
+        /// local mods received repos mods
+        /// </summary>
+        Merged = 9,
+        /// <summary>
+        /// local mods received conflicting repos mods
+        /// </summary>
+        Conflicted = 10,
+        /// <summary>
+        /// is unversioned but configured to be ignored
+        /// </summary>
+        Ignored = 11,
+        /// <summary>
+        /// an unversioned resource is in the way of the versioned resource
+        /// </summary>
+        Obstructed = 12,
+        /// <summary>
+        /// an unversioned path populated by an svn:externals property
+        /// </summary>
+        External = 13,
+        /// <summary>
+        /// a directory doesn't contain a complete entries list
+        /// </summary>
+        Incomplete = 14,
+    }
+}


### PR DESCRIPTION
Adds support for the `svn status` command.

Like I mentioned in the issue, the only hard part is deciphering what is useful out of the `SvnStatusResultArgs` since there is so much in there. I likened the `status` command close to the `info` command.

I'd be happy to rework any guidance on it. 

Thanks!

Fixes #2