### PR TITLE
(GH-83) Added SVN Vacuum command

### DIFF
--- a/src/Cake.Svn.Tests/Cake.Svn.Tests.csproj
+++ b/src/Cake.Svn.Tests/Cake.Svn.Tests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Fixtures\Export\SvnExporterFixture.cs" />
     <Compile Include="Fixtures\Info\SvnInfoFixture.cs" />
     <Compile Include="Fixtures\Update\SvnUpdaterFixture.cs" />
+    <Compile Include="Fixtures\Vacuum\SvnVacuumFixture.cs" />
     <Compile Include="Internal\Extensions\CheckArgumentExtensionsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Unit\CleanUp\SvnCleanUperTests.cs" />
@@ -82,6 +83,8 @@
     <Compile Include="Unit\Checkout\SvnCheckoutSettingsTests.cs" />
     <Compile Include="Unit\Update\SvnUpdaterTests.cs" />
     <Compile Include="Unit\Update\SvnUpdateSettingsTests.cs" />
+    <Compile Include="Unit\Vacuum\SvnVacuumSettingsTests.cs" />
+    <Compile Include="Unit\Vacuum\SvnVacuumTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Svn\Cake.Svn.csproj">

--- a/src/Cake.Svn.Tests/Fixtures/Vacuum/SvnVacuumFixture.cs
+++ b/src/Cake.Svn.Tests/Fixtures/Vacuum/SvnVacuumFixture.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Svn.Vacuum;
+using NSubstitute;
+
+namespace Cake.Svn.Tests.Fixtures.Vacuum
+{
+    internal sealed class SvnVacuumFixture
+    {
+        internal ICakeEnvironment Environment { get; set; }
+        internal ISvnClient SvnClient { get; set; }
+        internal SvnVacuumSettings Settings { get; set; }
+        internal DirectoryPath DirectoryPath { get; set; }
+        internal Func<ISvnClient> GetSvnClient;
+
+        internal SvnVacuumFixture()
+        {
+            Environment = Substitute.For<ICakeEnvironment>();
+            SvnClient = Substitute.For<ISvnClient>();
+            Settings = new SvnVacuumSettings();
+            DirectoryPath = new DirectoryPath(@"C:\test\");
+            GetSvnClient = () => SvnClient;
+        }
+
+        internal SvnVacuum CreateSvnVacuum()
+        {
+            return new SvnVacuum(Environment, GetSvnClient);
+        }
+
+        internal bool Vacuum()
+        {
+            var vacuum = CreateSvnVacuum();
+            return vacuum.Vacuum(DirectoryPath, Settings);
+        }
+    }
+}

--- a/src/Cake.Svn.Tests/Unit/Vacuum/SvnVacuumSettingsTests.cs
+++ b/src/Cake.Svn.Tests/Unit/Vacuum/SvnVacuumSettingsTests.cs
@@ -1,0 +1,25 @@
+﻿using Cake.Svn.Vacuum;
+using Xunit;
+
+namespace Cake.Svn.Tests.Unit.Vacuum
+{
+    public sealed class SvnVacuumSettingsTests
+    {
+        /// <summary>
+        /// Ensures the constructor sets the settings to the correct defaults,
+        /// which are the same defaults SharpSVN uses.
+        /// </summary>
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Not_Set_Include_Externals_By_Default()
+            {
+                // Given, When
+                var settings = new SvnVacuumSettings();
+
+                // Then
+                Assert.False(settings.IncludeExternals);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn.Tests/Unit/Vacuum/SvnVacuumTests.cs
+++ b/src/Cake.Svn.Tests/Unit/Vacuum/SvnVacuumTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Cake.Svn.Tests.Fixtures.Vacuum;
+using NSubstitute;
+using Xunit;
+
+namespace Cake.Svn.Tests.Unit.Vacuum
+{
+    public sealed class SvnVacuumTests
+    {
+        public sealed class TheConstructor
+        {
+            [Fact]
+            public void Should_Not_Throw_If_Parameters_Are_Set()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture();
+
+                // When
+                fixture.CreateSvnVacuum();
+            }
+
+            [Fact]
+            public void Should_Throw_If_Environment_Is_Null()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture
+                {
+                    Environment = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("environment", () => fixture.CreateSvnVacuum());
+            }
+
+            [Fact]
+            public void Should_Throw_If_SvnClient_Is_Null()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture
+                {
+                    GetSvnClient = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("clientFactoryMethod", () => fixture.CreateSvnVacuum());
+            }
+        }
+
+        public sealed class TheVacuumMethod
+        {
+            [Fact]
+            public void Should_Throw_If_Settings_Is_Null()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture
+                {
+                    Settings = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("settings", () => fixture.Vacuum());
+            }
+
+            [Fact]
+            public void Should_Throw_If_DirectoryPath_Is_Null()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture
+                {
+                    DirectoryPath = null
+                };
+
+                // When
+                // Then
+                Assert.Throws<ArgumentNullException>("path", () => fixture.Vacuum());
+            }
+
+            [Fact]
+            public void Should_Proxy_Call_To_SvnClient()
+            {
+                // Given
+                var fixture = new SvnVacuumFixture();
+
+                // When
+                fixture.Vacuum();
+
+                // Then
+                fixture.SvnClient.Received(1).Vacuum(fixture.DirectoryPath.ToString(), fixture.Settings);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn/Cake.Svn.csproj
+++ b/src/Cake.Svn/Cake.Svn.csproj
@@ -85,6 +85,7 @@
     <Compile Include="SvnAliases.Info.cs" />
     <Compile Include="SvnAliases.Delete.cs" />
     <Compile Include="SvnAliases.Update.cs" />
+    <Compile Include="SvnAliases.Vacuum.cs" />
     <Compile Include="SvnCredentials.cs" />
     <Compile Include="SvnClientArgsExtensions.cs" />
     <Compile Include="SvnKind.cs" />
@@ -102,6 +103,9 @@
     <Compile Include="Update\SvnUpdateResult.cs" />
     <Compile Include="Update\SvnUpdateSettings.cs" />
     <Compile Include="Update\SvnUpdateSettingsExtensions.cs" />
+    <Compile Include="Vacuum\SvnVacuum.cs" />
+    <Compile Include="Vacuum\SvnVacuumSettings.cs" />
+    <Compile Include="Vacuum\SvnVacuumSettingsExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="SvnAliases.Export.cs" />

--- a/src/Cake.Svn/ISvnClient.cs
+++ b/src/Cake.Svn/ISvnClient.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using Cake.Core.IO;
 using Cake.Svn.Add;
 using Cake.Svn.Checkout;
 using Cake.Svn.CleanUp;
@@ -9,6 +7,7 @@ using Cake.Svn.Delete;
 using Cake.Svn.Export;
 using Cake.Svn.Info;
 using Cake.Svn.Update;
+using Cake.Svn.Vacuum;
 
 namespace Cake.Svn
 {
@@ -95,5 +94,13 @@ namespace Cake.Svn
         /// <param name="settings">Settings to use.</param>
         /// <returns><c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.</returns>
         bool CleanUp(string directoryPath, SvnCleanUpSettings settings);
+
+        /// <summary>
+        /// Removes all unversioned and ignored files within the given directory.
+        /// </summary>
+        /// <param name="directoryPath">The path in the working copy to vacuum.</param>
+        /// <param name="settings">Settings to use.</param>
+        /// <returns><c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.</returns>
+        bool Vacuum(string directoryPath, SvnVacuumSettings settings);
     }
 }

--- a/src/Cake.Svn/Internal/SharpSvnClient.cs
+++ b/src/Cake.Svn/Internal/SharpSvnClient.cs
@@ -10,6 +10,7 @@ using Cake.Svn.Export;
 using Cake.Svn.Info;
 using Cake.Svn.Internal.Extensions;
 using Cake.Svn.Update;
+using Cake.Svn.Vacuum;
 using SharpSvn;
 using SharpSvn.Security;
 
@@ -146,6 +147,12 @@ namespace Cake.Svn.Internal
         public bool CleanUp(string directoryPath, SvnCleanUpSettings settings)
         {
             return CleanUp(directoryPath, settings.ToSvnCleanUpArgs());
+        }
+
+        /// <inheritdoc/>
+        public bool Vacuum(string directoryPath, SvnVacuumSettings settings)
+        {
+            return Vacuum(directoryPath, settings.ToSvnVacuumArgs());
         }
     }
 }

--- a/src/Cake.Svn/SvnAliases.Vacuum.cs
+++ b/src/Cake.Svn/SvnAliases.Vacuum.cs
@@ -36,7 +36,7 @@ namespace Cake.Svn
         }
 
         /// <summary>
-        /// Runs SVN vacuum on the given directory using default settings.
+        /// Runs SVN vacuum on the given directory using given settings settings.
         /// SVN vacuum removes all ignored and unversioned files and directories.
         /// This does not revert any modifications to files within the working copy.
         /// </summary>

--- a/src/Cake.Svn/SvnAliases.Vacuum.cs
+++ b/src/Cake.Svn/SvnAliases.Vacuum.cs
@@ -9,7 +9,8 @@ namespace Cake.Svn
     {
         /// <summary>
         /// Runs SVN vacuum on the given directory using default settings.
-        /// SVN vacuum removs all ignored and unversioned files and directories.
+        /// SVN vacuum removes all ignored and unversioned files and directories.
+        /// This does not revert any modifications to files within the working copy.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <param name="directory">The directory.</param>
@@ -36,7 +37,8 @@ namespace Cake.Svn
 
         /// <summary>
         /// Runs SVN vacuum on the given directory using default settings.
-        /// SVN vacuum removs all ignored and unversioned files and directories.
+        /// SVN vacuum removes all ignored and unversioned files and directories.
+        /// This does not revert any modifications to files within the working copy.
         /// </summary>
         /// <param name="context">The Cake context.</param>
         /// <param name="directory">The directory.</param>
@@ -45,7 +47,7 @@ namespace Cake.Svn
         /// <c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.
         /// </returns>
         /// <example>
-        /// <para>Cleans a directory inside of a SVN working copy.</para>
+        /// <para>Vacuums a directory inside of a SVN working copy.</para>
         /// <code>
         /// <![CDATA[ 
         ///     SvnVacuumSettings settings = new SvnVacuumSettings

--- a/src/Cake.Svn/SvnAliases.Vacuum.cs
+++ b/src/Cake.Svn/SvnAliases.Vacuum.cs
@@ -1,0 +1,71 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Svn.Vacuum;
+
+namespace Cake.Svn
+{
+    public static partial class SvnAliases
+    {
+        /// <summary>
+        /// Runs SVN vacuum on the given directory using default settings.
+        /// SVN vacuum removs all ignored and unversioned files and directories.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="directory">The directory.</param>
+        /// <returns>
+        /// <c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.
+        /// </returns>
+        /// <example>
+        /// <para>Vacuums a directory inside of a SVN working copy.</para>
+        /// <code>
+        /// <![CDATA[ 
+        ///     bool vacuumed = SvnVacuum(@"C:\project\src\");
+        ///
+        ///     Verbose("Directory Vacuumed: {0}", vacuumed);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Vacuum")]
+        [CakeNamespaceImport("Cake.Svn.Vacuum")]
+        public static bool SvnVacuum(this ICakeContext context, DirectoryPath directory)
+        {
+            return SvnVacuum(context, directory, new SvnVacuumSettings());
+        }
+
+        /// <summary>
+        /// Runs SVN vacuum on the given directory using default settings.
+        /// SVN vacuum removs all ignored and unversioned files and directories.
+        /// </summary>
+        /// <param name="context">The Cake context.</param>
+        /// <param name="directory">The directory.</param>
+        /// <param name="settings">Settings to use.</param>
+        /// <returns>
+        /// <c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.
+        /// </returns>
+        /// <example>
+        /// <para>Cleans a directory inside of a SVN working copy.</para>
+        /// <code>
+        /// <![CDATA[ 
+        ///     SvnVacuumSettings settings = new SvnVacuumSettings
+        ///     {
+        ///         IncludeExternals = true
+        ///     };
+        ///     bool vacuumed = SvnVacuum(@"C:\project\src\");
+        ///
+        ///     Verbose("Directory Vacuumed: {0}", vacuumed);
+        /// ]]>
+        /// </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Vacuum")]
+        [CakeNamespaceImport("Cake.Svn.Vacuum")]
+        public static bool SvnVacuum(this ICakeContext context, DirectoryPath directory, SvnVacuumSettings settings)
+        {
+            var vacuum = new SvnVacuum(context.Environment, SvnClientFactoryMethod);
+
+            return vacuum.Vacuum(directory, settings);
+        }
+    }
+}

--- a/src/Cake.Svn/Vacuum/SvnVacuum.cs
+++ b/src/Cake.Svn/Vacuum/SvnVacuum.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Cake.Core;
+using Cake.Core.IO;
+using Cake.Svn.Internal.Extensions;
+
+namespace Cake.Svn.Vacuum
+{
+    /// <summary>
+    /// Performs an SVN vacuum on the working copy.
+    /// This deletes all ignored or unversioned files from the working copy.
+    /// </summary>
+    public class SvnVacuum : SvnTool<SvnVacuumSettings>
+    {
+        private readonly ICakeEnvironment _environment;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SvnVacuum"/> class.
+        /// </summary>
+        /// <param name="environment">The Cake environment.</param>
+        /// <param name="clientFactoryMethod">Method to use to initialize a Subversion client.</param>
+        public SvnVacuum(ICakeEnvironment environment, Func<ISvnClient> clientFactoryMethod)
+            : base(clientFactoryMethod)
+        {
+            environment.NotNull(nameof(environment));
+            clientFactoryMethod.NotNull(nameof(clientFactoryMethod));
+
+            _environment = environment;
+        }
+
+        /// <summary>
+        /// Runs the SVN vacuum command.
+        /// </summary>
+        /// <param name="path">The path in the working copy to vacuum.</param>
+        /// <param name="settings">Settings to use.</param>
+        /// <returns>
+        /// <c>true</c> if the command was successful. Otherwise <c>false</c> will be returned.
+        /// </returns>
+        public bool Vacuum(DirectoryPath path, SvnVacuumSettings settings)
+        {
+            path.NotNull(nameof(path));
+            settings.NotNull(nameof(settings));
+
+            using (var client = GetClient())
+            {
+                string pathStr = path.MakeAbsolute(this._environment).ToString();
+                return client.Vacuum(pathStr, settings);
+            }
+        }
+    }
+}

--- a/src/Cake.Svn/Vacuum/SvnVacuumSettings.cs
+++ b/src/Cake.Svn/Vacuum/SvnVacuumSettings.cs
@@ -1,0 +1,15 @@
+﻿namespace Cake.Svn.Vacuum
+{
+    /// <summary>
+    /// Settings for <see cref="SvnVacuum"/>
+    /// </summary>
+    public sealed class SvnVacuumSettings : SvnSettings
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether vacuum should also process externals
+        /// defined by svn:externals properties.
+        /// Defaulted to <c>false</c>.
+        /// </summary>
+        public bool IncludeExternals { get; set; } = false;
+    }
+}

--- a/src/Cake.Svn/Vacuum/SvnVacuumSettingsExtensions.cs
+++ b/src/Cake.Svn/Vacuum/SvnVacuumSettingsExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Cake.Svn.Internal.Extensions;
+using SharpSvn;
+
+namespace Cake.Svn.Vacuum
+{
+    internal static class SvnVacuumSettingsExtensions
+    {
+        internal static SvnVacuumArgs ToSvnVacuumArgs(this SvnVacuumSettings settings)
+        {
+            settings.NotNull(nameof(settings));
+
+            return (new SvnVacuumArgs
+            {
+                IncludeExternals = settings.IncludeExternals
+            }
+            ).SetBaseSettings(settings);
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds the "Vacuum" command to Cake.Svn.  Vacuum in SharpSVN removes all ignored and unversioned files in the working copy.  Modifications, however, seem to be unaffected (which makes sense, that's revert's job).

How this was tested
-------

First, the following cake file was used:

```C#
#reference "C:\\Users\\xfore\\Documents\\Source\\Cake.Svn\\src\\Cake.Svn\\bin\\Debug\\Sharp.Svn.dll"
#reference "C:\\Users\\xfore\\Documents\\Source\\Cake.Svn\\src\\Cake.Svn\\bin\\Debug\\Cake.Svn.dll"

const string target = "cleanup";

Task( target )
.Does(
    () =>
    {
        DirectoryPath dir = Directory( "./TestRepoCo" );

        bool success = SvnVacuum( dir );
        Information( "Vacuumed: " + success );
    }
);

RunTarget( target );
```

Second, TestRepoCo has the following inside of it:

*IgnoredFolder
**IgnoredFile.txt
*MyFolder
**Test2.txt
*UnversionedFolder
**UnversionedFile
*Test.txt (modified)

Running "svn status" results in the following output:

```
> svn status
M       Test.txt
?       UnversionedFolder
> svn status .\IgnoredFolder\
I       IgnoredFolder
```

After invoking cake, all of the ignored and unversioned files went away, but the modified file was not reverted
(which makes sense as that should only be done with a "revert").

```
> svn status .\IgnoredFolder
> svn status
M       Test.txt
> dir


    Directory: TestRepoCo


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
d-----        10/7/2019   8:21 PM                MyFolder
-a----        10/9/2019   7:49 PM             19 Test.txt


>
```

Fixes #83 