### PR TITLE
Disable publishing to MyGet

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -2,23 +2,28 @@
 
 Environment.SetVariableNames();
 
-BuildParameters.SetParameters(context: Context, 
-                            buildSystem: BuildSystem,
-                            sourceDirectoryPath: "./src",
-                            title: "Cake.Svn",
-                            repositoryOwner: "cake-contrib",
-                            repositoryName: "Cake.Svn",
-                            appVeyorAccountName: "cakecontrib",
-                            shouldRunCodecov: false);
+BuildParameters.SetParameters(
+    context: Context, 
+    buildSystem: BuildSystem,
+    sourceDirectoryPath: "./src",
+    title: "Cake.Svn",
+    repositoryOwner: "cake-contrib",
+    repositoryName: "Cake.Svn",
+    appVeyorAccountName: "cakecontrib",
+    shouldPublishMyGet: false,
+    shouldRunCodecov: false);
 
 BuildParameters.PrintParameters(Context);
 
-ToolSettings.SetToolSettings(context: Context,
-                            dupFinderExcludePattern: new string[] { 
-                                BuildParameters.RootDirectoryPath + "/src/Cake.Svn.Tests/*.cs" },
-                            testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* ",
-                            testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
-                            testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs",
-                            buildPlatformTarget: PlatformTarget.x64);
+ToolSettings.SetToolSettings(
+    context: Context,
+    dupFinderExcludePattern: new string[] 
+    {
+        BuildParameters.RootDirectoryPath + "/src/Cake.Svn.Tests/*.cs"
+    },
+    testCoverageFilter: "+[*]* -[xunit.*]* -[Cake.Core]* -[Cake.Testing]* -[*.Tests]* ",
+    testCoverageExcludeByAttribute: "*.ExcludeFromCodeCoverage*",
+    testCoverageExcludeByFile: "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs",
+    buildPlatformTarget: PlatformTarget.x64);
 
 Build.Run();


### PR DESCRIPTION
Disable publishing of NuGet packages to MyGet, since we run out of quota. Once Cake.Recipe 2.0.0 is available we can enable publishing of CI package to GitHub.